### PR TITLE
fix: remove dynamicParams to fix status check

### DIFF
--- a/app/[locale]/(public)/product/[slug]/page.tsx
+++ b/app/[locale]/(public)/product/[slug]/page.tsx
@@ -16,7 +16,7 @@ import type { Metadata } from 'next';
 // Disable caching temporarily to ensure locale fixes take effect immediately
 // Updated: Force deployment refresh for 404 fix
 export const revalidate = 0;
-export const dynamicParams = false; // Force 404 for routes not in generateStaticParams
+// Removed dynamicParams = false to allow custom not-found.tsx to be used
 
 export async function generateStaticParams() {
   // Prebuild known product slugs for both locales so unknown slugs return 404 at the router level


### PR DESCRIPTION
Removes dynamicParams = false to allow custom not-found.tsx usage and fix failing CI status check. This is the root cause fix for the 404 detection issue.