### PR TITLE
fix: upgrade Node.js engine requirement to version 22 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20"
+    "node": "22"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Pin to Node.js 22 (current LTS) instead of >=20
- Prevents automatic upgrades to untested future Node.js versions
- Resolves Vercel deployment warning about unpredictable version upgrades
- Node.js 22 LTS is supported until April 2027

🤖 Generated with [Claude Code](https://claude.ai/code)