### PR TITLE
fix: restore beautiful blue colors in Tailwind v4

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,27 @@
 @theme {
   --font-family-sans: var(--font-inter), 'Inter', 'system-ui', 'sans-serif';
   --radius: 0.75rem;
+
+  /* Map colors to use CSS custom properties */
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 }
 
 @layer base {


### PR DESCRIPTION
Map CSS custom properties to Tailwind v4 color system properly:
- Add --color-* mappings in @theme directive
- Connect hsl(var(--primary)) to --color-primary
- Restore vibrant blue buttons and UI elements
- Fix complete color palette integration

This resolves the missing blue primary colors that were lost during the Tailwind v3 → v4 migration.

🤖 Generated with [Claude Code](https://claude.ai/code)