### PR TITLE
Fix navbar logo order to match footer layout

### DIFF
--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -127,14 +127,14 @@ export default function Navbar() {
               href={`/${locale}`}
               className={`flex items-center ${isRTL ? 'gap-3' : 'gap-3'}`}
             >
-              <span className="text-xl font-bold text-foreground hidden sm:block">
-                Kiara Kraft
-              </span>
               <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
                 <span className="text-primary-foreground font-bold text-lg">
                   K
                 </span>
               </div>
+              <span className="text-xl font-bold text-foreground hidden sm:block">
+                Kiara Kraft
+              </span>
             </Link>
           </div>
 


### PR DESCRIPTION
## Summary
- Reorder navbar logo elements to match footer layout consistency
- Move K logo icon before "Kiara Kraft" text in navbar
- Ensures consistent brand presentation across the site

## Test plan
- [ ] Verify navbar logo order matches footer layout
- [ ] Test both desktop and mobile views
- [ ] Confirm RTL/LTR layouts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)