### PR TITLE
fix: add missing auth.bio translation key

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -296,6 +296,7 @@
     "displayName": "Display Name",
     "region": "Region",
     "regionPlaceholder": "e.g., Tehran, Isfahan, Shiraz",
+    "bio": "Bio",
     "bioPlaceholder": "Tell us about your craft and experience...",
     "createAccount": "Create Account",
     "creating": "Creating...",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -296,6 +296,7 @@
     "displayName": "نام نمایشی",
     "region": "منطقه",
     "regionPlaceholder": "مثلاً تهران، اصفهان، شیراز",
+    "bio": "بیوگرافی",
     "bioPlaceholder": "درباره صنعت و تجربه‌تان بگویید...",
     "createAccount": "ایجاد حساب",
     "creating": "در حال ایجاد...",


### PR DESCRIPTION
- Added "bio" key to English translations ("Bio")
- Added "bio" key to Persian translations ("بیوگرافی")
- Fixes [Missing: auth.bio] error in seller registration form
- Bio field label now displays correctly in both languages

🤖 Generated with [Claude Code](https://claude.ai/code)