### PR TITLE
Fix test product filtering by marking demo products as test products

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -248,6 +248,7 @@ async function main() {
         sellerId: demoSeller.sellerProfile!.id,
         categoryId: product.categoryId,
         active: true,
+        isTest: true, // Mark demo products as test products to exclude from public listings
         images: {
           create: product.images.map((url, index) => ({
             url,


### PR DESCRIPTION
## Summary
- Fixed the issue where demo/seed products were appearing in featured products and explore page
- Updated seed.ts to set `isTest: true` for all demo products created during seeding
- Executed SQL to update existing demo products in database to be marked as test products

## Root Cause
The seed file was creating demo products but not marking them with `isTest: true`, causing them to appear in public listings despite having a filtering system in place.

## Changes Made
- Modified `prisma/seed.ts` to mark all demo products as test products during creation
- Updated existing demo products in the database to have `isTest: true`
- This ensures the existing filtering logic in search.ts properly excludes these products

## Test Plan
- [x] Verify demo products are marked as test products in database
- [x] Check that featured products no longer show demo products  
- [x] Check that explore page no longer shows demo products
- [x] Confirm filtering logic is working as expected

🤖 Generated with [Claude Code](https://claude.ai/code)