### PR TITLE
Fix: Show specific error message for login failures

### DIFF
--- a/app/[locale]/auth/login/page.tsx
+++ b/app/[locale]/auth/login/page.tsx
@@ -54,22 +54,12 @@ export default function LoginPage() {
       });
 
       if (result?.error) {
-        // Debug: Log the exact error to console
-        console.log('NextAuth error:', result.error);
-        console.log(
-          'Translation for invalidCredentials:',
-          t('invalidCredentials')
-        );
-        console.log('Translation for loginFailed:', t('loginFailed'));
-
-        // NextAuth v4 returns generic "CredentialsSignin" error
-        // Show specific message for most common case
-        if (result.error === 'CredentialsSignin') {
-          setError(t('invalidCredentials'));
-        } else {
-          // For any other error, show generic login failed
-          setError(t('loginFailed'));
-        }
+        // Always show specific error for wrong credentials
+        // NextAuth v4 returns "CredentialsSignin" for auth failures
+        setError(t('invalidCredentials'));
+      } else if (result?.ok === false) {
+        // Handle other types of failures
+        setError(t('invalidCredentials'));
       } else {
         // Redirect to the previous page or home
         const callbackUrl = new URLSearchParams(window.location.search).get(


### PR DESCRIPTION
## Summary
Simplified authentication error handling to always show the specific "Invalid email or password" message instead of generic "Login failed".

## Problem
User was seeing generic "خطا در ورود" (Login failed) message instead of the more helpful "ایمیل یا رمز عبور اشتباه است" (Invalid email or password).

## Solution
- Simplified error handling to always show `invalidCredentials` translation for any login error
- Removed debug console.log statements
- Handles both `error` and `ok=false` cases from NextAuth

## Test plan
- [x] Login with wrong credentials shows "Invalid email or password"
- [x] Works in both Persian and English
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.ai/code)