### PR TITLE
fix: Handle foreign key constraints in product deletion

### DIFF
--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -277,8 +277,33 @@ export async function DELETE(
       return NextResponse.json({ error: 'Product not found' }, { status: 404 });
     }
 
-    await prisma.product.delete({
-      where: { id: params.id },
+    // Delete related records first to handle foreign key constraints
+    await prisma.$transaction(async tx => {
+      // Delete related records
+      await tx.cartItem.deleteMany({
+        where: { productId: params.id },
+      });
+
+      await tx.wishlistItem.deleteMany({
+        where: { productId: params.id },
+      });
+
+      await tx.review.deleteMany({
+        where: { productId: params.id },
+      });
+
+      await tx.productTranslation.deleteMany({
+        where: { productId: params.id },
+      });
+
+      await tx.listingImage.deleteMany({
+        where: { productId: params.id },
+      });
+
+      // Finally delete the product
+      await tx.product.delete({
+        where: { id: params.id },
+      });
     });
 
     // Revalidate product-related caches post-delete

--- a/app/api/seller/products/cleanup/route.ts
+++ b/app/api/seller/products/cleanup/route.ts
@@ -96,23 +96,64 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    // Delete all products for this seller (both correct and incorrect sellerId)
-    const deleteCorrect = prisma.product.deleteMany({
-      where: { sellerId: user.sellerProfile.id },
+    // First, get all product IDs that belong to this seller
+    const productsToDelete = await prisma.product.findMany({
+      where: {
+        OR: [
+          { sellerId: user.sellerProfile.id },
+          { sellerId: user.id }, // In case of old bug
+        ],
+      },
+      select: { id: true },
     });
 
-    const deleteIncorrect = prisma.product.deleteMany({
-      where: { sellerId: user.id },
-    });
+    const productIds = productsToDelete.map(p => p.id);
 
-    const [result1, result2] = await prisma.$transaction([
-      deleteCorrect,
-      deleteIncorrect,
-    ]);
+    if (productIds.length === 0) {
+      return NextResponse.json({
+        message: 'No products to delete',
+        deletedCount: 0,
+      });
+    }
+
+    // Delete all related records first, then delete products
+    // This handles foreign key constraints
+    const result = await prisma.$transaction(async tx => {
+      // Delete related records in order of dependency
+      await tx.cartItem.deleteMany({
+        where: { productId: { in: productIds } },
+      });
+
+      await tx.wishlistItem.deleteMany({
+        where: { productId: { in: productIds } },
+      });
+
+      await tx.review.deleteMany({
+        where: { productId: { in: productIds } },
+      });
+
+      await tx.productTranslation.deleteMany({
+        where: { productId: { in: productIds } },
+      });
+
+      await tx.listingImage.deleteMany({
+        where: { productId: { in: productIds } },
+      });
+
+      // Note: We don't delete OrderItems as they're historical records
+      // Orders should remain intact even if products are deleted
+
+      // Finally, delete the products
+      const deleteResult = await tx.product.deleteMany({
+        where: { id: { in: productIds } },
+      });
+
+      return deleteResult.count;
+    });
 
     return NextResponse.json({
       message: 'All products deleted',
-      deletedCount: result1.count + result2.count,
+      deletedCount: result,
     });
   } catch (error) {
     console.error('Bulk delete error:', error);


### PR DESCRIPTION
## Summary
Fixes the "Failed to delete products" error that persisted even after the previous fix, by properly handling foreign key constraints.

## Problem
Even with the cleanup tools from PR #90, deletion was still failing because products have related records (cart items, wishlist items, reviews, etc.) that must be deleted first due to database foreign key constraints.

## Solution
Updated both individual and bulk delete to:
1. Delete all related records first in the correct order:
   - Cart items
   - Wishlist items  
   - Reviews
   - Product translations
   - Listing images
2. Then delete the product itself
3. Wrapped in database transactions for data integrity

## Changes
- Updated `/api/seller/products/[id]/route.ts` DELETE method
- Updated `/api/seller/products/cleanup/route.ts` DELETE method
- Both now handle cascading deletes properly

## Test plan
- [x] Individual delete buttons now work after removing constraints
- [x] "Delete All Products" button works without foreign key errors
- [x] Transactions ensure data consistency
- [x] Order items are preserved as historical records

🤖 Generated with [Claude Code](https://claude.ai/code)