### PR TITLE
fix: Remove test products from explore page

### DIFF
--- a/app/api/admin/clear-cache/route.ts
+++ b/app/api/admin/clear-cache/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { revalidateTag, revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+
+export async function POST() {
+  try {
+    // Check if user is admin
+    const session = await auth();
+    if (!session?.user || session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Revalidate all product-related caches
+    revalidateTag('products');
+    revalidateTag('categories');
+    revalidateTag('sellers');
+
+    // Revalidate the explore page paths
+    revalidatePath('/fa/explore');
+    revalidatePath('/en/explore');
+    revalidatePath('/explore');
+
+    return NextResponse.json({
+      message: 'Cache cleared successfully',
+      tags: ['products', 'categories', 'sellers'],
+      paths: ['/fa/explore', '/en/explore'],
+    });
+  } catch (error) {
+    console.error('Error clearing cache:', error);
+    return NextResponse.json(
+      { error: 'Failed to clear cache' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Problem
Three test products were showing in the explore page despite having a test filtering mechanism.

## Root Cause
The products were created yesterday with `isTest: false` instead of `true`:
- cmfcz0p11000gocv54ustu4kc
- cmfcz0mg1000aocv5l0wpp9wj  
- cmfcz0iuf0004ocv5t0mqyxbi

## Solution
1. ✅ Updated the 3 products in database to `isTest: true`
2. ✅ Added admin cache clearing endpoint to force cache refresh
3. 🔄 This deployment will clear cached results

## Testing
After deployment, the explore page should no longer show these test products.

The cache clearing endpoint can be used by admins if similar issues occur:
```
POST /api/admin/clear-cache
```

Closes the issue with test products appearing in production.