### PR TITLE
fix: Add bilingual support for AI assessment reasons

### DIFF
--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -533,13 +533,21 @@ async function processProductEnhancementAndAssessment({
     const assessmentResult = await assessProductWithAI(productToAssess);
 
     // Update product with final assessment results
+    // Store both English and Persian reasons as JSON
+    const bilingualReasons = {
+      en: assessmentResult.reasons?.join('; ') || '',
+      fa:
+        assessmentResult.reasons_fa?.join('; ') ||
+        assessmentResult.reasons?.join('; ') ||
+        '',
+    };
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons:
-          assessmentResult.reasons?.join('; ').slice(0, 1000) || null,
+        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
       },
     });
 

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -233,13 +233,21 @@ async function processProductEnhancementAndAssessment({
     const assessmentResult = await assessProductWithAI(productToAssess);
 
     // Update product with final assessment results
+    // Store both English and Persian reasons as JSON
+    const bilingualReasons = {
+      en: assessmentResult.reasons?.join('; ') || '',
+      fa:
+        assessmentResult.reasons_fa?.join('; ') ||
+        assessmentResult.reasons?.join('; ') ||
+        '',
+    };
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons:
-          assessmentResult.reasons?.join('; ').slice(0, 1000) || null,
+        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
       },
     });
 

--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import {
   Dialog,
   DialogContent,
@@ -29,6 +29,7 @@ export function ProductStatusBadge({
   onUpdate,
 }: ProductStatusBadgeProps) {
   const t = useTranslations('seller');
+  const locale = useLocale();
   const [open, setOpen] = useState(false);
   const [currentProduct, setCurrentProduct] = useState(product);
   const [isPolling, setIsPolling] = useState(false);
@@ -111,11 +112,46 @@ export function ProductStatusBadge({
 
   const progress = getProgress();
 
-  // Parse rejection reasons if they're separated by semicolons or bullet points
+  // Get localized reason text from bilingual JSON or fallback to plain text
+  const getLocalizedReasonText = (
+    reasons: string | null | undefined
+  ): string => {
+    if (!reasons) return '';
+
+    try {
+      const parsed = JSON.parse(reasons);
+      if (parsed && typeof parsed === 'object') {
+        return parsed[locale] || parsed.en || reasons;
+      }
+    } catch {
+      // Not JSON, return as is
+    }
+
+    return reasons;
+  };
+
+  // Parse rejection reasons - now handles bilingual JSON format
   const parseReasons = (reasons: string | null | undefined) => {
     if (!reasons) return [];
 
-    // Split by common separators
+    // Try to parse as JSON first (new format)
+    try {
+      const parsed = JSON.parse(reasons);
+      if (parsed && typeof parsed === 'object') {
+        // Get the appropriate language based on locale
+        const localizedReasons = parsed[locale] || parsed.en || '';
+        if (localizedReasons) {
+          return localizedReasons
+            .split(/[;•\n]/)
+            .map((r: string) => r.trim())
+            .filter((r: string) => r.length > 0);
+        }
+      }
+    } catch {
+      // If not JSON, fall back to old format
+    }
+
+    // Fall back to old format (plain string with separators)
     const parts = reasons
       .split(/[;•\n]/)
       .map(r => r.trim())
@@ -267,7 +303,9 @@ export function ProductStatusBadge({
                         {t('aiAssessment')}:
                       </p>
                       <p className="text-sm text-green-700 dark:text-green-300">
-                        {currentProduct.eligibilityReasons}
+                        {getLocalizedReasonText(
+                          currentProduct.eligibilityReasons
+                        )}
                       </p>
                     </div>
                   )}
@@ -305,7 +343,7 @@ export function ProductStatusBadge({
 
                       <ul className="space-y-2">
                         {parseReasons(currentProduct.eligibilityReasons).map(
-                          (reason, i) => (
+                          (reason: string, i: number) => (
                             <li
                               key={i}
                               className="text-sm flex items-start gap-2"

--- a/lib/moderation-ai.ts
+++ b/lib/moderation-ai.ts
@@ -11,6 +11,7 @@ type EligibilityResult = {
   status: 'APPROVED' | 'REJECTED';
   confidence: number; // 0-100
   reasons: string[];
+  reasons_fa?: string[];
 };
 
 // Define clear marketplace criteria
@@ -107,13 +108,17 @@ Analyze the product based on our criteria and respond with a JSON object contain
 1. status: "APPROVED" or "REJECTED" (definitive decision)
 2. confidence: number between 0-100 (your confidence level)
 3. reasons: array of strings (clear explanations for your decision)
+4. reasons_fa: array of strings (Persian/Farsi translation of the reasons)
 
 You MUST respond with valid JSON in this exact format:
 {
   "status": "APPROVED" or "REJECTED",
   "confidence": 85,
-  "reasons": ["reason 1", "reason 2", "reason 3"]
+  "reasons": ["English reason 1", "English reason 2", "English reason 3"],
+  "reasons_fa": ["دلیل فارسی ۱", "دلیل فارسی ۲", "دلیل فارسی ۳"]
 }
+
+IMPORTANT: Always provide BOTH English and Persian (Farsi) reasons. The Persian reasons should be natural Persian translations, not literal word-for-word translations.
 
 ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was provided, evaluate based on text only.'}`,
           },
@@ -188,8 +193,12 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
                 type: 'array',
                 items: { type: 'string' },
               },
+              reasons_fa: {
+                type: 'array',
+                items: { type: 'string' },
+              },
             },
-            required: ['status', 'confidence', 'reasons'],
+            required: ['status', 'confidence', 'reasons', 'reasons_fa'],
             additionalProperties: false,
           },
         },
@@ -207,6 +216,7 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
       status: 'APPROVED' | 'REJECTED';
       confidence: number;
       reasons: string[];
+      reasons_fa?: string[];
     };
 
     // Ensure status is only APPROVED or REJECTED
@@ -218,6 +228,7 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
       status: result.status,
       confidence: Math.max(0, Math.min(100, result.confidence)),
       reasons: result.reasons || [],
+      reasons_fa: result.reasons_fa || result.reasons || [],
     };
   } catch (error) {
     // Log detailed error information


### PR DESCRIPTION
## Problem
The AI assessment reasons were being displayed in English on both the Persian (fa) and English (en) pages, as shown in the screenshots provided.

## Solution
Added full bilingual support for AI assessment reasons:

### Changes Made:
1. **Modified AI Assessment** to generate both English and Persian reasons
   - Updated prompt to request reasons_fa array alongside reasons
   - Added JSON schema support for bilingual content

2. **Database Storage** 
   - Changed to store reasons as JSON with both languages
   - Format: `{"en": "English reasons", "fa": "Persian reasons"}`

3. **Frontend Display**
   - ProductStatusBadge now detects locale and displays appropriate language
   - Added fallback support for existing products with old format
   - Parses JSON and extracts correct language based on current locale

## Result
- Persian users see assessment reasons in Persian (فارسی)
- English users see assessment reasons in English
- Backwards compatible with existing data

## Test Plan
- [ ] Submit a new product and verify Persian reasons appear on fa pages
- [ ] Verify English reasons appear on en pages
- [ ] Check existing products still display correctly (fallback support)
- [ ] Verify both approved and rejected products show correct language

🤖 Generated with [Claude Code](https://claude.ai/code)