### PR TITLE
fix: Improve bilingual support for AI assessment reasons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,44 @@ kiarakraft/
 
 ---
 
+## AI Product Assessment Flow
+
+### Overview
+
+Products undergo AI assessment for marketplace eligibility using GPT-5 mini with bilingual support (English/Persian).
+
+### Process Flow
+
+1. **Product Creation/Update**: When a seller creates or updates a product
+2. **Immediate PENDING Status**: Product is set to PENDING with progress messages
+3. **Background Processing** (3 steps):
+   - Step 1: Product validation and initial checks
+   - Step 2: Enhancement with AI (improve descriptions, generate tags)
+   - Step 3: Eligibility assessment (APPROVED/REJECTED decision)
+
+### Bilingual Support
+
+- AI generates assessment reasons in both English and Persian
+- Stored as JSON in `eligibilityReasons` field: `{"en": "...", "fa": "..."}`
+- ProductStatusBadge component displays correct language based on locale
+- Important: JSON must not be truncated to preserve valid structure
+
+### Key Files
+
+- `/lib/moderation-ai.ts` - AI assessment logic with GPT-5 mini
+- `/lib/product-enhancement-openai.ts` - Product enhancement before assessment
+- `/app/api/seller/products/route.ts` - POST endpoint for new products
+- `/app/api/seller/products/[id]/route.ts` - PUT endpoint for updates
+- `/components/products/ProductStatusBadge.tsx` - Status display with bilingual support
+
+### Monitoring
+
+- Use `npx tsx scripts/watch-product-status.ts [productId]` to monitor status changes
+- Products poll every 3 seconds when PENDING to get updates
+- Check logs for AI processing steps and decisions
+
+---
+
 ## Important Notes
 
 ### Demo Accounts (after seeding)

--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -533,13 +533,21 @@ async function processProductEnhancementAndAssessment({
     const assessmentResult = await assessProductWithAI(productToAssess);
 
     // Update product with final assessment results
+    // Store both English and Persian reasons as JSON
+    const bilingualReasons = {
+      en: assessmentResult.reasons?.join('; ') || '',
+      fa:
+        assessmentResult.reasons_fa?.join('; ') ||
+        assessmentResult.reasons?.join('; ') ||
+        '',
+    };
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons:
-          assessmentResult.reasons?.join('; ').slice(0, 1000) || null,
+        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
       },
     });
 

--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -542,12 +542,23 @@ async function processProductEnhancementAndAssessment({
         '',
     };
 
+    // Ensure JSON string fits in database field (1000 chars)
+    // If too long, truncate individual reasons before JSON encoding
+    let jsonString = JSON.stringify(bilingualReasons);
+    if (jsonString.length > 1000) {
+      // Truncate individual reasons to fit
+      const maxReasonLength = 400; // Leave room for JSON structure
+      bilingualReasons.en = bilingualReasons.en.slice(0, maxReasonLength);
+      bilingualReasons.fa = bilingualReasons.fa.slice(0, maxReasonLength);
+      jsonString = JSON.stringify(bilingualReasons);
+    }
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
+        eligibilityReasons: jsonString,
       },
     });
 

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -233,13 +233,21 @@ async function processProductEnhancementAndAssessment({
     const assessmentResult = await assessProductWithAI(productToAssess);
 
     // Update product with final assessment results
+    // Store both English and Persian reasons as JSON
+    const bilingualReasons = {
+      en: assessmentResult.reasons?.join('; ') || '',
+      fa:
+        assessmentResult.reasons_fa?.join('; ') ||
+        assessmentResult.reasons?.join('; ') ||
+        '',
+    };
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons:
-          assessmentResult.reasons?.join('; ').slice(0, 1000) || null,
+        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
       },
     });
 

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -242,12 +242,23 @@ async function processProductEnhancementAndAssessment({
         '',
     };
 
+    // Ensure JSON string fits in database field (1000 chars)
+    // If too long, truncate individual reasons before JSON encoding
+    let jsonString = JSON.stringify(bilingualReasons);
+    if (jsonString.length > 1000) {
+      // Truncate individual reasons to fit
+      const maxReasonLength = 400; // Leave room for JSON structure
+      bilingualReasons.en = bilingualReasons.en.slice(0, maxReasonLength);
+      bilingualReasons.fa = bilingualReasons.fa.slice(0, maxReasonLength);
+      jsonString = JSON.stringify(bilingualReasons);
+    }
+
     await prisma.product.update({
       where: { id: product.id },
       data: {
         eligibilityStatus: assessmentResult.status,
         eligibilityConfidence: assessmentResult.confidence ?? null,
-        eligibilityReasons: JSON.stringify(bilingualReasons).slice(0, 1000),
+        eligibilityReasons: jsonString,
       },
     });
 
@@ -543,7 +554,8 @@ export const POST = withRateLimit(
           'fa',
           'en'
         )
-          .then(async en => {
+          .then(async (en: { title: string; description: string } | null) => {
+            if (!en) return;
             try {
               type PTClient = {
                 productTranslation: {
@@ -588,7 +600,7 @@ export const POST = withRateLimit(
               console.error('Failed to store EN translation', e);
             }
           })
-          .catch(e => console.error('Translation error', e));
+          .catch((e: unknown) => console.error('Translation error', e));
       }
 
       // Return product immediately with PENDING status while processing happens in background

--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import {
   Dialog,
   DialogContent,
@@ -29,6 +29,7 @@ export function ProductStatusBadge({
   onUpdate,
 }: ProductStatusBadgeProps) {
   const t = useTranslations('seller');
+  const locale = useLocale();
   const [open, setOpen] = useState(false);
   const [currentProduct, setCurrentProduct] = useState(product);
   const [isPolling, setIsPolling] = useState(false);
@@ -111,11 +112,46 @@ export function ProductStatusBadge({
 
   const progress = getProgress();
 
-  // Parse rejection reasons if they're separated by semicolons or bullet points
+  // Get localized reason text from bilingual JSON or fallback to plain text
+  const getLocalizedReasonText = (
+    reasons: string | null | undefined
+  ): string => {
+    if (!reasons) return '';
+
+    try {
+      const parsed = JSON.parse(reasons);
+      if (parsed && typeof parsed === 'object') {
+        return parsed[locale] || parsed.en || reasons;
+      }
+    } catch {
+      // Not JSON, return as is
+    }
+
+    return reasons;
+  };
+
+  // Parse rejection reasons - now handles bilingual JSON format
   const parseReasons = (reasons: string | null | undefined) => {
     if (!reasons) return [];
 
-    // Split by common separators
+    // Try to parse as JSON first (new format)
+    try {
+      const parsed = JSON.parse(reasons);
+      if (parsed && typeof parsed === 'object') {
+        // Get the appropriate language based on locale
+        const localizedReasons = parsed[locale] || parsed.en || '';
+        if (localizedReasons) {
+          return localizedReasons
+            .split(/[;•\n]/)
+            .map((r: string) => r.trim())
+            .filter((r: string) => r.length > 0);
+        }
+      }
+    } catch {
+      // If not JSON, fall back to old format
+    }
+
+    // Fall back to old format (plain string with separators)
     const parts = reasons
       .split(/[;•\n]/)
       .map(r => r.trim())
@@ -267,7 +303,9 @@ export function ProductStatusBadge({
                         {t('aiAssessment')}:
                       </p>
                       <p className="text-sm text-green-700 dark:text-green-300">
-                        {currentProduct.eligibilityReasons}
+                        {getLocalizedReasonText(
+                          currentProduct.eligibilityReasons
+                        )}
                       </p>
                     </div>
                   )}
@@ -305,7 +343,7 @@ export function ProductStatusBadge({
 
                       <ul className="space-y-2">
                         {parseReasons(currentProduct.eligibilityReasons).map(
-                          (reason, i) => (
+                          (reason: string, i: number) => (
                             <li
                               key={i}
                               className="text-sm flex items-start gap-2"

--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -86,15 +86,24 @@ export function ProductStatusBadge({
   const getProgress = () => {
     const reasons = currentProduct.eligibilityReasons || '';
 
-    if (reasons.includes('Step 3/3') || reasons.includes('Assessing product')) {
+    // Convert reasons to string if it's not already (for safety)
+    const reasonsStr = typeof reasons === 'string' ? reasons : String(reasons);
+
+    if (
+      reasonsStr.includes('Step 3/3') ||
+      reasonsStr.includes('Assessing product')
+    ) {
       return { step: 3, label: t('aiProcessing.step3'), percent: 90 };
     }
-    if (reasons.includes('Step 2/3') || reasons.includes('Enhancing product')) {
+    if (
+      reasonsStr.includes('Step 2/3') ||
+      reasonsStr.includes('Enhancing product')
+    ) {
       return { step: 2, label: t('aiProcessing.step2'), percent: 60 };
     }
     if (
-      reasons.includes('Step 1/3') ||
-      reasons.includes('Validating product')
+      reasonsStr.includes('Step 1/3') ||
+      reasonsStr.includes('Validating product')
     ) {
       return { step: 1, label: t('aiProcessing.step1'), percent: 30 };
     }
@@ -118,37 +127,86 @@ export function ProductStatusBadge({
   ): string => {
     if (!reasons) return '';
 
-    try {
-      const parsed = JSON.parse(reasons);
-      if (parsed && typeof parsed === 'object') {
-        return parsed[locale] || parsed.en || reasons;
-      }
-    } catch {
-      // Not JSON, return as is
+    // If it's a PENDING status with progress messages, return as is
+    if (currentProduct.eligibilityStatus === 'PENDING') {
+      return typeof reasons === 'string' ? reasons : '';
     }
 
-    return reasons;
+    // Only try to parse JSON for APPROVED/REJECTED statuses
+    if (typeof reasons === 'string') {
+      // Try to parse as JSON - check for JSON-like structure
+      const trimmedReasons = reasons.trim();
+      if (trimmedReasons.startsWith('{') && trimmedReasons.endsWith('}')) {
+        try {
+          const parsed = JSON.parse(trimmedReasons);
+          if (parsed && typeof parsed === 'object') {
+            // Get the appropriate language based on locale
+            // The JSON structure is { en: "...", fa: "..." }
+            const localizedText = parsed[locale] || parsed.en || '';
+            // Return the cleaned text
+            return typeof localizedText === 'string'
+              ? localizedText.trim()
+              : '';
+          }
+        } catch (e) {
+          // Not valid JSON, log for debugging
+          console.warn(
+            'Failed to parse reasons as JSON:',
+            e,
+            'Raw:',
+            trimmedReasons.substring(0, 100)
+          );
+        }
+      }
+    }
+
+    // Fallback: return as is
+    return typeof reasons === 'string' ? reasons : '';
   };
 
   // Parse rejection reasons - now handles bilingual JSON format
-  const parseReasons = (reasons: string | null | undefined) => {
+  const parseReasons = (reasons: string | null | undefined): string[] => {
     if (!reasons) return [];
 
-    // Try to parse as JSON first (new format)
-    try {
-      const parsed = JSON.parse(reasons);
-      if (parsed && typeof parsed === 'object') {
-        // Get the appropriate language based on locale
-        const localizedReasons = parsed[locale] || parsed.en || '';
-        if (localizedReasons) {
-          return localizedReasons
-            .split(/[;•\n]/)
-            .map((r: string) => r.trim())
-            .filter((r: string) => r.length > 0);
+    // Don't try to parse if it's not a string
+    if (typeof reasons !== 'string') return [];
+
+    // For PENDING status, don't try to parse as array
+    if (currentProduct.eligibilityStatus === 'PENDING') {
+      return [];
+    }
+
+    const trimmedReasons = reasons.trim();
+
+    // Try to parse as JSON if it looks like JSON
+    if (trimmedReasons.startsWith('{') && trimmedReasons.endsWith('}')) {
+      try {
+        const parsed = JSON.parse(trimmedReasons);
+        if (parsed && typeof parsed === 'object') {
+          // Get the appropriate language based on locale
+          // The JSON structure is { en: "...", fa: "..." }
+          const localizedReasons = parsed[locale] || parsed.en || '';
+          if (localizedReasons && typeof localizedReasons === 'string') {
+            // Split by semicolons and clean up
+            const reasonsList = localizedReasons
+              .split(';')
+              .map((r: string) => r.trim())
+              .filter((r: string) => r.length > 0 && r !== '.');
+
+            // If we got valid reasons, return them
+            if (reasonsList.length > 0) {
+              return reasonsList;
+            }
+          }
         }
+      } catch (e) {
+        console.warn(
+          'Failed to parse reasons as JSON:',
+          e,
+          'Raw:',
+          trimmedReasons.substring(0, 100)
+        );
       }
-    } catch {
-      // If not JSON, fall back to old format
     }
 
     // Fall back to old format (plain string with separators)
@@ -254,8 +312,9 @@ export function ProductStatusBadge({
                 <div className="bg-muted/50 rounded-lg p-3">
                   <p className="text-sm font-medium mb-1">{progress.label}</p>
                   <p className="text-xs text-muted-foreground">
-                    {currentProduct.eligibilityReasons ||
-                      t('aiProcessing.processingDescription')}
+                    {getLocalizedReasonText(
+                      currentProduct.eligibilityReasons
+                    ) || t('aiProcessing.processingDescription')}
                   </p>
                 </div>
 
@@ -302,11 +361,34 @@ export function ProductStatusBadge({
                       <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-1">
                         {t('aiAssessment')}:
                       </p>
-                      <p className="text-sm text-green-700 dark:text-green-300">
-                        {getLocalizedReasonText(
-                          currentProduct.eligibilityReasons
-                        )}
-                      </p>
+                      <div className="text-sm text-green-700 dark:text-green-300">
+                        {(() => {
+                          const reasonText = getLocalizedReasonText(
+                            currentProduct.eligibilityReasons
+                          );
+                          // Check if we have a semicolon-separated list
+                          if (reasonText.includes(';')) {
+                            const reasons = reasonText
+                              .split(';')
+                              .map(r => r.trim())
+                              .filter(r => r);
+                            return (
+                              <ul className="space-y-1">
+                                {reasons.map((reason, i) => (
+                                  <li
+                                    key={i}
+                                    className="flex items-start gap-1"
+                                  >
+                                    <span className="text-green-600">•</span>
+                                    <span>{reason}</span>
+                                  </li>
+                                ))}
+                              </ul>
+                            );
+                          }
+                          return <p>{reasonText}</p>;
+                        })()}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/lib/moderation-ai.ts
+++ b/lib/moderation-ai.ts
@@ -118,7 +118,12 @@ You MUST respond with valid JSON in this exact format:
   "reasons_fa": ["دلیل فارسی ۱", "دلیل فارسی ۲", "دلیل فارسی ۳"]
 }
 
-IMPORTANT: Always provide BOTH English and Persian (Farsi) reasons. The Persian reasons should be natural Persian translations, not literal word-for-word translations.
+IMPORTANT: 
+- Always provide BOTH English and Persian (Farsi) reasons
+- The reasons array MUST contain English text only
+- The reasons_fa array MUST contain Persian/Farsi text only (using Persian script: فارسی)
+- Persian reasons should be natural translations that make sense to Persian speakers
+- Do NOT mix languages in either array
 
 ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was provided, evaluate based on text only.'}`,
           },

--- a/lib/moderation-ai.ts
+++ b/lib/moderation-ai.ts
@@ -11,6 +11,7 @@ type EligibilityResult = {
   status: 'APPROVED' | 'REJECTED';
   confidence: number; // 0-100
   reasons: string[];
+  reasons_fa?: string[];
 };
 
 // Define clear marketplace criteria
@@ -107,13 +108,17 @@ Analyze the product based on our criteria and respond with a JSON object contain
 1. status: "APPROVED" or "REJECTED" (definitive decision)
 2. confidence: number between 0-100 (your confidence level)
 3. reasons: array of strings (clear explanations for your decision)
+4. reasons_fa: array of strings (Persian/Farsi translation of the reasons)
 
 You MUST respond with valid JSON in this exact format:
 {
   "status": "APPROVED" or "REJECTED",
   "confidence": 85,
-  "reasons": ["reason 1", "reason 2", "reason 3"]
+  "reasons": ["English reason 1", "English reason 2", "English reason 3"],
+  "reasons_fa": ["دلیل فارسی ۱", "دلیل فارسی ۲", "دلیل فارسی ۳"]
 }
+
+IMPORTANT: Always provide BOTH English and Persian (Farsi) reasons. The Persian reasons should be natural Persian translations, not literal word-for-word translations.
 
 ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was provided, evaluate based on text only.'}`,
           },
@@ -188,8 +193,12 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
                 type: 'array',
                 items: { type: 'string' },
               },
+              reasons_fa: {
+                type: 'array',
+                items: { type: 'string' },
+              },
             },
-            required: ['status', 'confidence', 'reasons'],
+            required: ['status', 'confidence', 'reasons', 'reasons_fa'],
             additionalProperties: false,
           },
         },
@@ -207,6 +216,7 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
       status: 'APPROVED' | 'REJECTED';
       confidence: number;
       reasons: string[];
+      reasons_fa?: string[];
     };
 
     // Ensure status is only APPROVED or REJECTED
@@ -218,6 +228,7 @@ ${input.imageUrl ? 'An image of the product is provided below.' : 'No image was 
       status: result.status,
       confidence: Math.max(0, Math.min(100, result.confidence)),
       reasons: result.reasons || [],
+      reasons_fa: result.reasons_fa || result.reasons || [],
     };
   } catch (error) {
     // Log detailed error information

--- a/scripts/watch-product-status.ts
+++ b/scripts/watch-product-status.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env tsx
+
+import { PrismaClient } from '@prisma/client';
+import * as dotenv from 'dotenv';
+import { resolve } from 'path';
+
+// Load environment variables
+dotenv.config({ path: resolve(process.cwd(), '.env.local') });
+dotenv.config({ path: resolve(process.cwd(), '.env') });
+
+const prisma = new PrismaClient();
+
+async function watchProductStatus() {
+  console.log('🔍 Watching Product Status Updates\n');
+
+  // Get product ID from command line argument
+  const productId = process.argv[2];
+
+  if (!productId) {
+    // Watch all PENDING products
+    console.log('Watching all PENDING products...\n');
+
+    while (true) {
+      const pendingProducts = await prisma.product.findMany({
+        where: { eligibilityStatus: 'PENDING' },
+        select: {
+          id: true,
+          title: true,
+          eligibilityStatus: true,
+          eligibilityReasons: true,
+          updatedAt: true,
+        },
+        orderBy: { updatedAt: 'desc' },
+      });
+
+      if (pendingProducts.length > 0) {
+        console.clear();
+        console.log(`📊 PENDING Products: ${pendingProducts.length}\n`);
+
+        for (const product of pendingProducts) {
+          console.log(`ID: ${product.id}`);
+          console.log(`Title: ${product.title}`);
+          console.log(`Status: ${product.eligibilityStatus}`);
+          console.log(
+            `Reasons: ${product.eligibilityReasons?.substring(0, 100)}...`
+          );
+          console.log(`Updated: ${product.updatedAt.toLocaleTimeString()}`);
+          console.log('---');
+        }
+      } else {
+        console.log('No PENDING products found.');
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  } else {
+    // Watch specific product
+    console.log(`Watching product ${productId}...\n`);
+
+    let lastStatus = '';
+    let lastReasons = '';
+
+    while (true) {
+      const product = await prisma.product.findUnique({
+        where: { id: productId },
+        select: {
+          id: true,
+          title: true,
+          eligibilityStatus: true,
+          eligibilityReasons: true,
+          eligibilityConfidence: true,
+          updatedAt: true,
+        },
+      });
+
+      if (!product) {
+        console.log(`Product ${productId} not found.`);
+        break;
+      }
+
+      // Check if status or reasons changed
+      if (
+        product.eligibilityStatus !== lastStatus ||
+        product.eligibilityReasons !== lastReasons
+      ) {
+        console.log(`\n[${new Date().toLocaleTimeString()}] Update detected:`);
+        console.log(`Title: ${product.title}`);
+        console.log(`Status: ${product.eligibilityStatus}`);
+
+        if (product.eligibilityConfidence) {
+          console.log(`Confidence: ${product.eligibilityConfidence}%`);
+        }
+
+        if (product.eligibilityReasons) {
+          console.log(`\nReasons (raw):`);
+          console.log(product.eligibilityReasons);
+
+          // Try to parse as JSON
+          try {
+            const parsed = JSON.parse(product.eligibilityReasons);
+            console.log(`\nReasons (parsed):`);
+            console.log('English:', parsed.en);
+            console.log('Persian:', parsed.fa);
+          } catch (e) {
+            // Not JSON, show as is
+          }
+        }
+
+        lastStatus = product.eligibilityStatus || '';
+        lastReasons = product.eligibilityReasons || '';
+
+        // Stop watching if product is no longer PENDING
+        if (product.eligibilityStatus !== 'PENDING') {
+          console.log(`\n✅ Product processing complete!`);
+          break;
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+}
+
+watchProductStatus()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- Fixed JSON parsing in ProductStatusBadge to properly extract localized content
- Prevented JSON truncation that was breaking parsing
- Ensured proper language separation (Persian on fa pages, English on en pages)

## Problem
The AI assessment reasons were displaying in English on Persian pages, and clicking the status badge was causing React hydration errors due to malformed JSON.

## Solution
1. **Fixed JSON truncation**: Now truncate individual reason strings before JSON encoding to ensure valid JSON structure
2. **Improved JSON parsing**: Added proper null checks and error handling in ProductStatusBadge
3. **Language separation**: Component now correctly displays Persian reasons on fa pages and English on en pages
4. **Added monitoring tools**: Created watch-product-status.ts script for debugging

## Changes
- Updated `/lib/moderation-ai.ts` to generate bilingual assessment reasons
- Fixed `/app/api/seller/products/route.ts` and `[id]/route.ts` to prevent JSON truncation
- Improved `/components/products/ProductStatusBadge.tsx` JSON parsing logic
- Added `/scripts/watch-product-status.ts` for monitoring product status updates
- Documented AI flow in CLAUDE.md for future Claude sessions

## Testing
- TypeScript checks pass ✅
- ESLint checks pass ✅
- Dev server runs without errors ✅
- JSON parsing works correctly for both languages

🤖 Generated with [Claude Code](https://claude.ai/code)