### PR TITLE
fix: Resolve React hydration error #185 in ProductStatusBadge

### DIFF
--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -332,7 +332,7 @@ export function ProductStatusBadge({
               {currentProduct.eligibilityStatus === 'PENDING' && (
                 <div className="relative">
                   <Clock className="w-16 h-16 text-yellow-500 animate-pulse" />
-                  {isMounted && isPolling && (
+                  {isPolling && (
                     <RefreshCw className="absolute -bottom-2 -right-2 w-4 h-4 text-muted-foreground animate-spin" />
                   )}
                 </div>
@@ -364,11 +364,9 @@ export function ProductStatusBadge({
                   </p>
                 </div>
 
-                {isMounted && (
-                  <div className="text-xs text-center text-muted-foreground">
-                    {t('aiProcessing.autoRefresh')}
-                  </div>
-                )}
+                <div className="text-xs text-center text-muted-foreground">
+                  {t('aiProcessing.autoRefresh')}
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- Fixed React hydration error #185 that occurred when clicking on product status badges
- Removed conditional rendering based on `isMounted` state that caused server/client HTML mismatch
- Ensures consistent rendering between server and client

## Problem
When users clicked on the "Under Review" (or any status) badge on a product, they encountered:
- React minified error #185 
- Hydration mismatch due to conditional rendering with `isMounted` checks
- Different HTML generated on server vs client

## Solution
Removed `isMounted` checks from render output:
- Changed `{isMounted && isPolling && <RefreshCw />}` to `{isPolling && <RefreshCw />}`
- Removed `isMounted` wrapper around auto-refresh text
- These elements are safe to render as they're inside a Dialog (client-only interaction)

## Test Plan
- [x] Verified no TypeScript errors with `npm run typecheck`
- [x] Verified no ESLint errors with `npm run lint`
- [x] Tested clicking on product status badges - no console errors
- [x] Verified bilingual content displays correctly in both locales
- [x] Confirmed polling still works for PENDING status products

## Screenshots
Before: React error #185 in console when clicking status badge
After: Clean console, no hydration errors

🤖 Generated with [Claude Code](https://claude.ai/code)