### PR TITLE
fix: Separate bilingual content in product descriptions

### DIFF
--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -159,6 +159,55 @@ async function processProductEnhancementAndAssessment({
         });
         console.log(`✅ Enhanced description and tags saved`);
 
+        // Save English translation if provided
+        if (enhancement.descriptionEn) {
+          try {
+            // Check if translation already exists
+            const existingTranslation =
+              await prisma.productTranslation.findUnique({
+                where: {
+                  productId_locale: {
+                    productId: product.id,
+                    locale: 'en',
+                  },
+                },
+              });
+
+            if (existingTranslation) {
+              // Update existing translation
+              await prisma.productTranslation.update({
+                where: {
+                  productId_locale: {
+                    productId: product.id,
+                    locale: 'en',
+                  },
+                },
+                data: {
+                  description: enhancement.descriptionEn,
+                },
+              });
+              console.log(`✅ Updated English translation`);
+            } else {
+              // Create new translation
+              await prisma.productTranslation.create({
+                data: {
+                  productId: product.id,
+                  locale: 'en',
+                  title: product.title, // Will need proper translation later
+                  description: enhancement.descriptionEn,
+                },
+              });
+              console.log(`✅ Created English translation`);
+            }
+          } catch (translationError) {
+            console.error(
+              'Failed to save English translation:',
+              translationError
+            );
+            // Don't fail the whole process if translation save fails
+          }
+        }
+
         // Update progress
         await prisma.product.update({
           where: { id: product.id },

--- a/lib/product-enhancement-openai.ts
+++ b/lib/product-enhancement-openai.ts
@@ -10,7 +10,8 @@ import {
 } from '@/lib/security-utils';
 
 type EnhancementResult = {
-  enhancedDescription: string;
+  enhancedDescription: string; // Persian/original language description
+  enhancedDescriptionEn?: string; // English translation if original is Persian
   suggestedTags: string[];
   imageEnhancementTips?: string[];
   enhancedImageUrl?: string;
@@ -71,8 +72,9 @@ When analyzing the product image for realistic improvements, identify:
 - Professional composition (center product, adjust angle for best presentation)
 - Keep the product 100% realistic - no fantasy elements or major alterations
 
-IMPORTANT: 
-- For Persian/Farsi products, maintain bilingual descriptions
+IMPORTANT:
+- For Persian/Farsi products, DO NOT mix languages in descriptions
+- Keep Persian and English descriptions SEPARATE in the JSON response
 - Highlight what makes this product special and handmade
 - If the product seems mass-produced, be honest but try to find unique selling points
 - Always maintain ethical standards - no false claims
@@ -123,7 +125,8 @@ ${input.imageUrl ? 'An image of the product is provided for analysis.' : 'No ima
 
 Analyze the product and provide enhancements. You MUST respond with valid JSON in the following format:
 {
-  "enhancedDescription": "Improved detailed description (300-500 characters)",
+  "enhancedDescription": "Improved description in ORIGINAL language (Persian if input is Persian, 300-500 chars)",
+  "enhancedDescriptionEn": "English translation/version ONLY if original is Persian (300-500 chars, null if already English)",
   "suggestedTags": ["tag1", "tag2", ...] (max 10),
   "imageEnhancementTips": ["specific improvement suggestions for seller"],
   "imageEditPrompt": "Brief prompt for realistic photo enhancement focusing ONLY on: better lighting, clean background, sharp focus, correct colors. DO NOT change the product itself",
@@ -193,6 +196,7 @@ Focus on highlighting handmade qualities and improving marketability.`,
             type: 'object',
             properties: {
               enhancedDescription: { type: 'string' },
+              enhancedDescriptionEn: { type: ['string', 'null'] },
               suggestedTags: {
                 type: 'array',
                 items: { type: 'string' },
@@ -236,6 +240,7 @@ Focus on highlighting handmade qualities and improving marketability.`,
     // Parse the JSON response
     const result = JSON.parse(response) as {
       enhancedDescription: string;
+      enhancedDescriptionEn?: string | null;
       suggestedTags: string[];
       imageEnhancementTips?: string[];
       imageEditPrompt?: string;
@@ -260,6 +265,7 @@ Focus on highlighting handmade qualities and improving marketability.`,
 
     return {
       enhancedDescription: result.enhancedDescription,
+      enhancedDescriptionEn: result.enhancedDescriptionEn || undefined,
       suggestedTags: result.suggestedTags.slice(0, 10),
       imageEnhancementTips: result.imageEnhancementTips,
       enhancedImageUrl,
@@ -412,6 +418,7 @@ export async function enhanceProductBeforeApproval(product: {
 }): Promise<{
   enhanced: boolean;
   description?: string;
+  descriptionEn?: string;
   tags?: string[];
   imageUrl?: string;
 }> {
@@ -452,6 +459,7 @@ export async function enhanceProductBeforeApproval(product: {
       return {
         enhanced: true,
         description: enhancement.enhancedDescription || product.description,
+        descriptionEn: enhancement.enhancedDescriptionEn,
         tags: enhancement.suggestedTags || [],
         imageUrl: enhancement.enhancedImageUrl || product.imageUrl,
       };

--- a/scripts/fix-mixed-descriptions.ts
+++ b/scripts/fix-mixed-descriptions.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * Fix mixed language descriptions in products
+ *
+ * Problem: Product enhancement was concatenating English translations
+ * to Persian descriptions, creating mixed-language content in a single field.
+ *
+ * Solution: Split the mixed content and store English in ProductTranslation table
+ */
+
+import { prisma } from '../lib/db';
+
+async function fixMixedDescriptions() {
+  console.log('🔍 Finding products with mixed language descriptions...\n');
+
+  try {
+    // Find all products with descriptions containing both Persian and English
+    const products = await prisma.product.findMany({
+      where: {
+        AND: [
+          { description: { contains: ' ' } }, // Has content
+          { isTest: false }, // Not test products
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        slug: true,
+      },
+    });
+
+    console.log(`Found ${products.length} products to check\n`);
+
+    let fixedCount = 0;
+    let alreadyFixedCount = 0;
+
+    for (const product of products) {
+      const description = product.description;
+
+      // Check if description contains both Persian and English
+      const hasPersian = /[\u0600-\u06FF]/.test(description);
+      const hasEnglish = /[a-zA-Z]{2,}/.test(description);
+
+      if (hasPersian && hasEnglish) {
+        console.log(`\n📦 Product: ${product.title} (${product.slug})`);
+        console.log(
+          `   Mixed content detected (length: ${description.length})`
+        );
+
+        // Try to split by common patterns
+        // Pattern 1: Look for a clear English section after Persian
+        // Pattern 2: Look for paragraph breaks
+
+        let persianPart = '';
+        let englishPart = '';
+
+        // Split by double newline or obvious language transition
+        const paragraphs = description.split(/\n\n|\.\s+[A-Z]/);
+
+        for (const para of paragraphs) {
+          const isPersian = /[\u0600-\u06FF]/.test(para);
+          const isEnglish = /^[A-Za-z\s]/.test(para.trim());
+
+          if (isPersian && !isEnglish) {
+            persianPart += (persianPart ? '\n\n' : '') + para.trim();
+          } else if (isEnglish && !isPersian) {
+            englishPart += (englishPart ? '\n\n' : '') + para.trim();
+          } else if (isPersian && isEnglish) {
+            // Mixed paragraph - try to split by sentence
+            const sentences = para.split(/[.؟!]\s+/);
+            for (const sentence of sentences) {
+              if (/[\u0600-\u06FF]/.test(sentence)) {
+                persianPart += (persianPart ? '. ' : '') + sentence.trim();
+              } else if (/[a-zA-Z]/.test(sentence)) {
+                englishPart += (englishPart ? '. ' : '') + sentence.trim();
+              }
+            }
+          }
+        }
+
+        // Alternative split: Find where Persian ends and English begins
+        if (!englishPart && hasEnglish) {
+          // Look for the first continuous English sentence
+          const match = description.match(
+            /[A-Z][a-z].+[.!?](?:\s+[A-Z][a-z].+[.!?])*/
+          );
+          if (match) {
+            const englishStart = description.indexOf(match[0]);
+            persianPart = description.substring(0, englishStart).trim();
+            englishPart = description.substring(englishStart).trim();
+          }
+        }
+
+        if (persianPart && englishPart) {
+          console.log(`   ✂️  Split into:`);
+          console.log(
+            `      Persian (${persianPart.length} chars): ${persianPart.substring(0, 50)}...`
+          );
+          console.log(
+            `      English (${englishPart.length} chars): ${englishPart.substring(0, 50)}...`
+          );
+
+          // Check if translation already exists
+          const existingTranslation =
+            await prisma.productTranslation.findUnique({
+              where: {
+                productId_locale: {
+                  productId: product.id,
+                  locale: 'en',
+                },
+              },
+            });
+
+          if (existingTranslation) {
+            console.log(`   ⚠️  Translation already exists, skipping`);
+            alreadyFixedCount++;
+          } else {
+            // Update product with Persian only
+            await prisma.product.update({
+              where: { id: product.id },
+              data: { description: persianPart },
+            });
+
+            // Create English translation
+            await prisma.productTranslation.create({
+              data: {
+                productId: product.id,
+                locale: 'en',
+                title: product.title, // Will need proper translation later
+                description: englishPart,
+              },
+            });
+
+            console.log(
+              `   ✅ Fixed! Persian saved to main, English to translation`
+            );
+            fixedCount++;
+          }
+        } else {
+          console.log(`   ⚠️  Could not reliably split content`);
+        }
+      }
+    }
+
+    console.log('\n' + '='.repeat(60));
+    console.log(`📊 Summary:`);
+    console.log(`   - ${fixedCount} products fixed`);
+    console.log(`   - ${alreadyFixedCount} already had translations`);
+    console.log(
+      `   - ${products.length - fixedCount - alreadyFixedCount} unchanged`
+    );
+
+    if (fixedCount > 0) {
+      console.log('\n✅ Mixed descriptions have been separated!');
+      console.log('   Persian text remains in main description field');
+      console.log('   English text moved to ProductTranslation table');
+    }
+  } catch (error) {
+    console.error('❌ Error:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the fix
+fixMixedDescriptions().catch(console.error);


### PR DESCRIPTION
## Summary
Fixes the issue where product enhancement was concatenating English translations to Persian descriptions, creating mixed-language content in a single database field.

## Problem
- Product descriptions showed both Persian and English text mixed together
- AI enhancement was appending English translation to the same field as Persian
- Users saw mixed bilingual content in the UI (as shown in screenshots)

## Solution

### 1. Modified AI Enhancement (`lib/product-enhancement-openai.ts`)
- Changed to generate separate outputs:
  - `enhancedDescription`: Persian/original language only
  - `enhancedDescriptionEn`: English translation (when applicable)
- Instructed AI to NOT mix languages in descriptions

### 2. Updated Save Logic (`app/api/seller/products/route.ts`)
- Persian stays in main `description` field
- English saved to `ProductTranslation` table with `locale: 'en'`
- Handles both create and update cases

### 3. Migration Script (`scripts/fix-mixed-descriptions.ts`)
- Created script to fix existing mixed descriptions
- Splits content by language and saves appropriately
- Safe to run multiple times (idempotent)

## Testing
- ✅ TypeScript check passes
- ✅ ESLint passes  
- ✅ Migration script runs successfully
- ✅ New products will have separated languages
- ✅ Existing mixed products can be fixed with the script

## Before/After
**Before**: Description field contained both "کلاه قرمز زمستانی..." AND "Classic warm red winter beanie..."
**After**: Persian in `description`, English in `ProductTranslation` table

## Impact
- Clean separation of languages in database
- UI will show only the appropriate language based on locale
- No more mixed Persian/English content displayed to users

## Next Steps
After merging, need to:
1. Run migration script on production to fix existing products
2. Verify new product enhancements work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)