### PR TITLE
fix: Enable proper Persian text enhancement by adding locale parameter

### DIFF
--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -402,6 +402,7 @@ async function processProductEnhancementAndAssessment({
       categorySlug,
       price: product.priceToman,
       userId,
+      locale: 'fa', // Default to Persian for Iranian marketplace
     });
 
     if (enhancement.enhanced) {

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -89,6 +89,7 @@ async function processProductEnhancementAndAssessment({
       categorySlug,
       price: product.priceToman,
       userId,
+      locale: 'fa', // Default to Persian for Iranian marketplace
     });
 
     if (enhancement.enhanced) {

--- a/lib/product-enhancement-openai.ts
+++ b/lib/product-enhancement-openai.ts
@@ -415,6 +415,7 @@ export async function enhanceProductBeforeApproval(product: {
   categorySlug?: string;
   price?: number;
   userId?: string;
+  locale?: 'fa' | 'en';
 }): Promise<{
   enhanced: boolean;
   description?: string;
@@ -432,6 +433,7 @@ export async function enhanceProductBeforeApproval(product: {
       categorySlug: product.categorySlug,
       price: product.price,
       userId: product.userId,
+      locale: product.locale || 'fa', // Default to Persian if not specified
     });
 
     // Always apply all available enhancements


### PR DESCRIPTION
## Summary
Fixes the issue where product enhancement wasn't working for Persian products due to missing locale parameter.

## Problem
Products were not being enhanced with:
- ❌ Rich, detailed Persian descriptions
- ❌ Persian tags and keywords
- ❌ Culturally-relevant enhancements

The AI didn't know it was processing Persian text because the `locale` parameter was missing from enhancement calls.

## Solution
Added `locale: 'fa'` parameter to all `enhanceProductBeforeApproval` calls:
- ✅ POST route (`/api/seller/products/route.ts`)
- ✅ PUT route (`/api/seller/products/[id]/route.ts`)
- ✅ Updated function signature in `lib/product-enhancement-openai.ts`

## Before/After

**Before:**
```
کلاه قرمز دستباف مخصوص زمستان
```
(Simple, no enhancement, no tags)

**After (Expected):**
```
کلاه قرمز دستباف مخصوص زمستان با بافت فشرده و نرم، مناسب برای روزهای سرد. 
طراحی کلاسیک با لبه تا خورده، از نخ آکریلیک باکیفیت...
```
Plus tags like: `دستباف`, `زمستانی`, `کلاه بافتنی`, `آکریلیک`, etc.

## Testing
- ✅ TypeScript check passes
- ✅ Locale parameter properly passed to AI
- ✅ AI will now understand it's processing Persian text

## Impact
- Products will get properly enhanced Persian descriptions
- Tags will be generated for better search/discovery
- AI will provide culturally-appropriate enhancements for Iranian marketplace

🤖 Generated with [Claude Code](https://claude.ai/code)