### PR TITLE
fix: Render dialog content client-only to prevent hydration error #185

### DIFF
--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -364,167 +364,181 @@ export function ProductStatusBadge({
       {/* Detail Modal - Render consistently to avoid hydration issues */}
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-md" suppressHydrationWarning>
-          <DialogHeader>
-            <DialogTitle>{t('productReviewStatus')}</DialogTitle>
-          </DialogHeader>
+          {/* Only render dialog content on client to avoid hydration issues */}
+          {mounted && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{t('productReviewStatus')}</DialogTitle>
+              </DialogHeader>
 
-          <div className="space-y-4">
-            {/* Status Icon */}
-            <div className="flex justify-center">
-              {currentProduct.eligibilityStatus === 'APPROVED' && (
-                <CheckCircle className="w-16 h-16 text-green-500" />
-              )}
-              {currentProduct.eligibilityStatus === 'REJECTED' && (
-                <XCircle className="w-16 h-16 text-red-500" />
-              )}
-              {currentProduct.eligibilityStatus === 'PENDING' && (
-                <Clock className="w-16 h-16 text-yellow-500 animate-pulse" />
-              )}
-            </div>
-
-            {/* Progress Bar for PENDING */}
-            {currentProduct.eligibilityStatus === 'PENDING' && progress && (
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <div className="flex justify-between text-sm">
-                    <span className="font-medium">
-                      {t('aiProcessing.step')} {progress.step}{' '}
-                      {t('aiProcessing.of')} 3
-                    </span>
-                    <span className="text-muted-foreground">
-                      {progress.percent}%
-                    </span>
-                  </div>
-                  <Progress value={progress.percent} className="h-2" />
+              <div className="space-y-4">
+                {/* Status Icon */}
+                <div className="flex justify-center">
+                  {currentProduct.eligibilityStatus === 'APPROVED' && (
+                    <CheckCircle className="w-16 h-16 text-green-500" />
+                  )}
+                  {currentProduct.eligibilityStatus === 'REJECTED' && (
+                    <XCircle className="w-16 h-16 text-red-500" />
+                  )}
+                  {currentProduct.eligibilityStatus === 'PENDING' && (
+                    <Clock className="w-16 h-16 text-yellow-500 animate-pulse" />
+                  )}
                 </div>
 
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <p className="text-sm font-medium mb-1">{progress.label}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {getLocalizedReasonText(
-                      currentProduct.eligibilityReasons
-                    ) || t('aiProcessing.processingDescription')}
-                  </p>
-                </div>
-
-                <div className="text-xs text-center text-muted-foreground">
-                  {t('aiProcessing.autoRefresh')}
-                </div>
-              </div>
-            )}
-
-            {/* Approval Details */}
-            {currentProduct.eligibilityStatus === 'APPROVED' && (
-              <div className="space-y-3">
-                <div className="bg-green-50 dark:bg-green-950/30 rounded-lg p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <CheckCircle className="w-5 h-5 text-green-600" />
-                    <span className="font-semibold text-green-900 dark:text-green-100">
-                      {t('productApproved')}
-                    </span>
-                  </div>
-
-                  {currentProduct.eligibilityConfidence && (
-                    <div className="flex items-center gap-2 mb-3">
-                      <span className="text-sm text-green-800 dark:text-green-200">
-                        {t('aiConfidence')}:
-                      </span>
-                      <div className="flex items-center gap-1">
-                        <div className="w-24 bg-green-200 dark:bg-green-800 rounded-full h-2">
-                          <div
-                            className="bg-green-600 h-2 rounded-full transition-all"
-                            style={{
-                              width: `${currentProduct.eligibilityConfidence}%`,
-                            }}
-                          />
-                        </div>
-                        <span className="text-sm font-medium text-green-800 dark:text-green-200">
-                          {currentProduct.eligibilityConfidence}%
+                {/* Progress Bar for PENDING */}
+                {currentProduct.eligibilityStatus === 'PENDING' && progress && (
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <div className="flex justify-between text-sm">
+                        <span className="font-medium">
+                          {t('aiProcessing.step')} {progress.step}{' '}
+                          {t('aiProcessing.of')} 3
+                        </span>
+                        <span className="text-muted-foreground">
+                          {progress.percent}%
                         </span>
                       </div>
+                      <Progress value={progress.percent} className="h-2" />
                     </div>
-                  )}
 
-                  {approvalReasonContent && (
-                    <div>
-                      <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-1">
-                        {t('aiAssessment')}:
+                    <div className="bg-muted/50 rounded-lg p-3">
+                      <p className="text-sm font-medium mb-1">
+                        {progress.label}
                       </p>
-                      <div className="text-sm text-green-700 dark:text-green-300">
-                        {approvalReasonContent.type === 'list' ? (
-                          <ul className="space-y-1">
-                            {approvalReasonContent.reasons.map((reason, i) => (
-                              <li key={i} className="flex items-start gap-1">
-                                <span className="text-green-600">•</span>
-                                <span>{reason}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : (
-                          <p>{approvalReasonContent.text}</p>
-                        )}
+                      <p className="text-xs text-muted-foreground">
+                        {getLocalizedReasonText(
+                          currentProduct.eligibilityReasons
+                        ) || t('aiProcessing.processingDescription')}
+                      </p>
+                    </div>
+
+                    <div className="text-xs text-center text-muted-foreground">
+                      {t('aiProcessing.autoRefresh')}
+                    </div>
+                  </div>
+                )}
+
+                {/* Approval Details */}
+                {currentProduct.eligibilityStatus === 'APPROVED' && (
+                  <div className="space-y-3">
+                    <div className="bg-green-50 dark:bg-green-950/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        <CheckCircle className="w-5 h-5 text-green-600" />
+                        <span className="font-semibold text-green-900 dark:text-green-100">
+                          {t('productApproved')}
+                        </span>
                       </div>
-                    </div>
-                  )}
-                </div>
-
-                <div className="bg-blue-50 dark:bg-blue-950/30 rounded-lg p-3">
-                  <p className="text-sm text-blue-800 dark:text-blue-200">
-                    <strong>{t('nextSteps')}:</strong> {t('approvedNextSteps')}
-                  </p>
-                </div>
-              </div>
-            )}
-
-            {/* Rejection Details */}
-            {currentProduct.eligibilityStatus === 'REJECTED' && (
-              <div className="space-y-3">
-                <div className="bg-red-50 dark:bg-red-950/30 rounded-lg p-4">
-                  <div className="flex items-start gap-2 mb-3">
-                    <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
-                    <div className="flex-1">
-                      <p className="font-semibold text-red-900 dark:text-red-100 mb-2">
-                        {t('rejectionReasons')}:
-                      </p>
 
                       {currentProduct.eligibilityConfidence && (
-                        <div className="flex items-center gap-2 mb-2">
-                          <span className="text-sm text-red-700 dark:text-red-300">
+                        <div className="flex items-center gap-2 mb-3">
+                          <span className="text-sm text-green-800 dark:text-green-200">
                             {t('aiConfidence')}:
                           </span>
-                          <span className="text-sm font-medium text-red-800 dark:text-red-200">
-                            {currentProduct.eligibilityConfidence}%
-                          </span>
+                          <div className="flex items-center gap-1">
+                            <div className="w-24 bg-green-200 dark:bg-green-800 rounded-full h-2">
+                              <div
+                                className="bg-green-600 h-2 rounded-full transition-all"
+                                style={{
+                                  width: `${currentProduct.eligibilityConfidence}%`,
+                                }}
+                              />
+                            </div>
+                            <span className="text-sm font-medium text-green-800 dark:text-green-200">
+                              {currentProduct.eligibilityConfidence}%
+                            </span>
+                          </div>
                         </div>
                       )}
 
-                      <ul className="space-y-2">
-                        {parseReasons(currentProduct.eligibilityReasons).map(
-                          (reason: string, i: number) => (
-                            <li
-                              key={i}
-                              className="text-sm flex items-start gap-2"
-                            >
-                              <span className="text-red-500 mt-0.5">•</span>
-                              <span className="text-red-700 dark:text-red-300">
-                                {reason}
-                              </span>
-                            </li>
-                          )
-                        )}
-                      </ul>
+                      {approvalReasonContent && (
+                        <div>
+                          <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-1">
+                            {t('aiAssessment')}:
+                          </p>
+                          <div className="text-sm text-green-700 dark:text-green-300">
+                            {approvalReasonContent.type === 'list' ? (
+                              <ul className="space-y-1">
+                                {approvalReasonContent.reasons.map(
+                                  (reason, i) => (
+                                    <li
+                                      key={i}
+                                      className="flex items-start gap-1"
+                                    >
+                                      <span className="text-green-600">•</span>
+                                      <span>{reason}</span>
+                                    </li>
+                                  )
+                                )}
+                              </ul>
+                            ) : (
+                              <p>{approvalReasonContent.text}</p>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="bg-blue-50 dark:bg-blue-950/30 rounded-lg p-3">
+                      <p className="text-sm text-blue-800 dark:text-blue-200">
+                        <strong>{t('nextSteps')}:</strong>{' '}
+                        {t('approvedNextSteps')}
+                      </p>
                     </div>
                   </div>
-                </div>
+                )}
 
-                <div className="bg-yellow-50 dark:bg-yellow-950/30 rounded-lg p-4">
-                  <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                    <strong>{t('whatToDo')}:</strong> {t('rejectedNextSteps')}
-                  </p>
-                </div>
+                {/* Rejection Details */}
+                {currentProduct.eligibilityStatus === 'REJECTED' && (
+                  <div className="space-y-3">
+                    <div className="bg-red-50 dark:bg-red-950/30 rounded-lg p-4">
+                      <div className="flex items-start gap-2 mb-3">
+                        <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+                        <div className="flex-1">
+                          <p className="font-semibold text-red-900 dark:text-red-100 mb-2">
+                            {t('rejectionReasons')}:
+                          </p>
+
+                          {currentProduct.eligibilityConfidence && (
+                            <div className="flex items-center gap-2 mb-2">
+                              <span className="text-sm text-red-700 dark:text-red-300">
+                                {t('aiConfidence')}:
+                              </span>
+                              <span className="text-sm font-medium text-red-800 dark:text-red-200">
+                                {currentProduct.eligibilityConfidence}%
+                              </span>
+                            </div>
+                          )}
+
+                          <ul className="space-y-2">
+                            {parseReasons(
+                              currentProduct.eligibilityReasons
+                            ).map((reason: string, i: number) => (
+                              <li
+                                key={i}
+                                className="text-sm flex items-start gap-2"
+                              >
+                                <span className="text-red-500 mt-0.5">•</span>
+                                <span className="text-red-700 dark:text-red-300">
+                                  {reason}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="bg-yellow-50 dark:bg-yellow-950/30 rounded-lg p-4">
+                      <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                        <strong>{t('whatToDo')}:</strong>{' '}
+                        {t('rejectedNextSteps')}
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
-            )}
-          </div>
+            </>
+          )}
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary
This PR definitively resolves React hydration error #185 by rendering the dialog content only on the client side after hydration completes.

## Root Cause
The hydration error persisted because:
1. **Translations (`t()`)** may not be immediately available or consistent between server and client
2. **Dynamic data** in the dialog could differ between server and client renders
3. **Complex conditional rendering** based on product status and reasons

Even after removing IIFE patterns, the translations and dynamic content could still cause mismatches.

## Solution
- Wrapped entire dialog content in `mounted && (...)` check
- Dialog shell (DialogContent wrapper) still renders on both server and client
- All dynamic content only renders after `mounted` becomes `true` (post-hydration)
- This ensures translations are fully loaded and data is consistent

## Why This Works
By deferring ALL dynamic content rendering until after hydration:
1. Server sends empty dialog content (just the shell)
2. Client hydrates with the same empty content (no mismatch)
3. After hydration, `mounted` becomes `true` and content renders
4. No hydration errors possible since dynamic content never participates in hydration

## Testing
- ✅ Build completes successfully
- ✅ No TypeScript errors
- ✅ Dialog still functions correctly (opens, shows content, closes)
- ✅ All features preserved (progress tracking, status display, translations)

This is a definitive fix that eliminates any possibility of hydration mismatch by completely avoiding server-side rendering of dynamic content.

Fixes #185

🤖 Generated with [Claude Code](https://claude.ai/code)