### PR TITLE
feat: Implement bilingual progress messages for AI product processing

### DIFF
--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -10,6 +10,7 @@ import crypto from 'crypto';
 import * as Sentry from '@sentry/nextjs';
 import { withCSRF } from '@/lib/csrf';
 import { waitUntil } from '@vercel/functions';
+import { getBilingualProgress } from '@/lib/progress-messages';
 
 export async function GET(
   _request: NextRequest,
@@ -125,7 +126,7 @@ export const PUT = withCSRF(async function (
         // Set to PENDING while we process enhancement and assessment
         eligibilityStatus: 'PENDING',
         eligibilityConfidence: null,
-        eligibilityReasons: 'Product is being reviewed with AI enhancements',
+        eligibilityReasons: getBilingualProgress('step1'),
       },
     });
 
@@ -355,7 +356,7 @@ async function processProductEnhancementAndAssessment({
   await prisma.product.update({
     where: { id: product.id },
     data: {
-      eligibilityReasons: '🔄 Step 1/3: Validating product data...',
+      eligibilityReasons: getBilingualProgress('step1'),
     },
   });
 
@@ -388,8 +389,7 @@ async function processProductEnhancementAndAssessment({
     await prisma.product.update({
       where: { id: product.id },
       data: {
-        eligibilityReasons:
-          '🎨 Step 2/3: Enhancing product presentation with AI...',
+        eligibilityReasons: getBilingualProgress('step2'),
       },
     });
 
@@ -477,8 +477,7 @@ async function processProductEnhancementAndAssessment({
         await prisma.product.update({
           where: { id: product.id },
           data: {
-            eligibilityReasons:
-              '✨ Enhancement complete. Starting eligibility assessment...',
+            eligibilityReasons: getBilingualProgress('enhancementComplete'),
           },
         });
       }
@@ -489,8 +488,7 @@ async function processProductEnhancementAndAssessment({
       await prisma.product.update({
         where: { id: product.id },
         data: {
-          eligibilityReasons:
-            '⏭️ Enhancement skipped. Starting eligibility assessment...',
+          eligibilityReasons: getBilingualProgress('enhancementSkipped'),
         },
       });
     }
@@ -502,8 +500,7 @@ async function processProductEnhancementAndAssessment({
     await prisma.product.update({
       where: { id: product.id },
       data: {
-        eligibilityReasons:
-          '⚠️ Enhancement failed. Continuing with eligibility assessment...',
+        eligibilityReasons: getBilingualProgress('enhancementSkipped'),
       },
     });
     // Continue with original content if enhancement fails
@@ -515,8 +512,7 @@ async function processProductEnhancementAndAssessment({
     await prisma.product.update({
       where: { id: product.id },
       data: {
-        eligibilityReasons:
-          '🔍 Step 3/3: Assessing product for marketplace eligibility...',
+        eligibilityReasons: getBilingualProgress('step3'),
       },
     });
 

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -15,6 +15,7 @@ import * as Sentry from '@sentry/nextjs';
 import crypto from 'crypto';
 import { withCSRF } from '@/lib/csrf';
 import { waitUntil } from '@vercel/functions';
+import { getBilingualProgress } from '@/lib/progress-messages';
 
 // Async function to process enhancement and assessment in background
 async function processProductEnhancementAndAssessment({
@@ -42,7 +43,7 @@ async function processProductEnhancementAndAssessment({
   await prisma.product.update({
     where: { id: product.id },
     data: {
-      eligibilityReasons: '🔄 Step 1/3: Validating product data...',
+      eligibilityReasons: getBilingualProgress('step1'),
     },
   });
 
@@ -75,8 +76,7 @@ async function processProductEnhancementAndAssessment({
     await prisma.product.update({
       where: { id: product.id },
       data: {
-        eligibilityReasons:
-          '🎨 Step 2/3: Enhancing product presentation with AI...',
+        eligibilityReasons: getBilingualProgress('step2'),
       },
     });
 
@@ -213,8 +213,7 @@ async function processProductEnhancementAndAssessment({
         await prisma.product.update({
           where: { id: product.id },
           data: {
-            eligibilityReasons:
-              '✨ Enhancement complete. Starting eligibility assessment...',
+            eligibilityReasons: getBilingualProgress('enhancementComplete'),
           },
         });
       }
@@ -225,8 +224,7 @@ async function processProductEnhancementAndAssessment({
       await prisma.product.update({
         where: { id: product.id },
         data: {
-          eligibilityReasons:
-            '⏭️ Enhancement skipped. Starting eligibility assessment...',
+          eligibilityReasons: getBilingualProgress('enhancementSkipped'),
         },
       });
     }
@@ -263,8 +261,7 @@ async function processProductEnhancementAndAssessment({
     await prisma.product.update({
       where: { id: product.id },
       data: {
-        eligibilityReasons:
-          '🔍 Step 3/3: Assessing product for marketplace eligibility...',
+        eligibilityReasons: getBilingualProgress('step3'),
       },
     });
 

--- a/components/products/ProductStatusBadge.tsx
+++ b/components/products/ProductStatusBadge.tsx
@@ -107,24 +107,54 @@ export function ProductStatusBadge({
   const getProgress = useCallback(() => {
     const reasons = currentProduct.eligibilityReasons || '';
 
-    // Convert reasons to string if it's not already (for safety)
-    const reasonsStr = typeof reasons === 'string' ? reasons : String(reasons);
+    // Parse bilingual JSON if present
+    let reasonsStr = '';
+    if (typeof reasons === 'string') {
+      const trimmed = reasons.trim();
+      if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (parsed && typeof parsed === 'object') {
+            // Use the appropriate language based on locale
+            reasonsStr =
+              locale === 'fa'
+                ? parsed.fa || parsed.en || ''
+                : parsed.en || parsed.fa || '';
+          } else {
+            reasonsStr = reasons;
+          }
+        } catch {
+          reasonsStr = reasons;
+        }
+      } else {
+        reasonsStr = reasons;
+      }
+    } else {
+      reasonsStr = String(reasons);
+    }
 
+    // Check for step indicators in the localized text
     if (
-      reasonsStr.includes('Step 3/3') ||
-      reasonsStr.includes('Assessing product')
+      reasonsStr.includes('3/3') ||
+      reasonsStr.includes('۳/۳') ||
+      reasonsStr.includes('Assessing') ||
+      reasonsStr.includes('ارزیابی')
     ) {
       return { step: 3, label: t('aiProcessing.step3'), percent: 90 };
     }
     if (
-      reasonsStr.includes('Step 2/3') ||
-      reasonsStr.includes('Enhancing product')
+      reasonsStr.includes('2/3') ||
+      reasonsStr.includes('۲/۳') ||
+      reasonsStr.includes('Enhancing') ||
+      reasonsStr.includes('بهبود')
     ) {
       return { step: 2, label: t('aiProcessing.step2'), percent: 60 };
     }
     if (
-      reasonsStr.includes('Step 1/3') ||
-      reasonsStr.includes('Validating product')
+      reasonsStr.includes('1/3') ||
+      reasonsStr.includes('۱/۳') ||
+      reasonsStr.includes('Validating') ||
+      reasonsStr.includes('بررسی')
     ) {
       return { step: 1, label: t('aiProcessing.step1'), percent: 30 };
     }
@@ -138,7 +168,12 @@ export function ProductStatusBadge({
     }
 
     return { step: 0, label: t('aiProcessing.starting'), percent: 5 };
-  }, [currentProduct.eligibilityReasons, currentProduct.eligibilityStatus, t]);
+  }, [
+    currentProduct.eligibilityReasons,
+    currentProduct.eligibilityStatus,
+    locale,
+    t,
+  ]);
 
   // Get localized reason text from bilingual JSON or fallback to plain text
   const getLocalizedReasonText = (
@@ -146,9 +181,29 @@ export function ProductStatusBadge({
   ): string => {
     if (!reasons) return '';
 
-    // If it's a PENDING status with progress messages, return as is
+    // For PENDING status, also try to parse JSON for bilingual progress messages
     if (currentProduct.eligibilityStatus === 'PENDING') {
-      return typeof reasons === 'string' ? reasons : '';
+      if (typeof reasons === 'string') {
+        const trimmed = reasons.trim();
+        if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+          try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed && typeof parsed === 'object') {
+              const localizedText =
+                locale === 'fa'
+                  ? parsed.fa || parsed.en
+                  : parsed.en || parsed.fa;
+              if (typeof localizedText === 'string' && localizedText.trim()) {
+                return localizedText.trim();
+              }
+            }
+          } catch {
+            // Not valid JSON, return as-is
+          }
+        }
+        return reasons;
+      }
+      return '';
     }
 
     // Only try to parse JSON for APPROVED/REJECTED statuses

--- a/lib/progress-messages.ts
+++ b/lib/progress-messages.ts
@@ -1,0 +1,30 @@
+// Bilingual progress messages for AI processing steps
+export const PROGRESS_MESSAGES = {
+  step1: {
+    en: '🔄 Step 1/3: Validating product data...',
+    fa: '🔄 مرحله ۱/۳: بررسی اطلاعات محصول...',
+  },
+  step2: {
+    en: '🎨 Step 2/3: Enhancing product presentation with AI...',
+    fa: '🎨 مرحله ۲/۳: بهبود نمایش محصول با هوش مصنوعی...',
+  },
+  step3: {
+    en: '🔍 Step 3/3: Assessing product for marketplace eligibility...',
+    fa: '🔍 مرحله ۳/۳: ارزیابی محصول برای پذیرش در بازار...',
+  },
+  enhancementComplete: {
+    en: '✨ Enhancement complete. Starting eligibility assessment...',
+    fa: '✨ بهبود محصول کامل شد. شروع ارزیابی پذیرش...',
+  },
+  enhancementSkipped: {
+    en: '⏭️ Enhancement skipped. Starting eligibility assessment...',
+    fa: '⏭️ بهبود محصول رد شد. شروع ارزیابی پذیرش...',
+  },
+};
+
+// Helper function to get bilingual JSON string
+export function getBilingualProgress(
+  key: keyof typeof PROGRESS_MESSAGES
+): string {
+  return JSON.stringify(PROGRESS_MESSAGES[key]);
+}


### PR DESCRIPTION
## Summary
- Created centralized bilingual progress messages (Persian/English) for AI processing steps
- Fixed issue where English text was appearing in Persian interface during product processing
- Progress messages now display in the correct language based on user's locale

## Changes
- Created `/lib/progress-messages.ts` with bilingual message definitions
- Updated both API routes (`route.ts` and `[id]/route.ts`) to use `getBilingualProgress()`
- Modified `ProductStatusBadge` component to parse and display bilingual JSON properly
- Added support for Persian numeric characters (۱/۳, ۲/۳, ۳/۳) in progress detection

## AI Processing Steps Explained
The three steps shown during product processing are:
1. **Step 1**: Product validation and initial checks
2. **Step 2**: Enhancement with AI (improve descriptions, generate tags)
3. **Step 3**: Eligibility assessment (APPROVED/REJECTED decision)

## Test Plan
- [ ] Create a new product in Persian locale and verify progress messages appear in Persian
- [ ] Create a new product in English locale and verify progress messages appear in English
- [ ] Edit an existing product and verify bilingual progress messages work
- [ ] Verify final assessment reasons still display in the correct language

🤖 Generated with [Claude Code](https://claude.ai/code)