### PR TITLE
fix: Implement bilingual tags with clickable links

### DIFF
--- a/app/[locale]/(public)/product/[slug]/page.tsx
+++ b/app/[locale]/(public)/product/[slug]/page.tsx
@@ -468,25 +468,57 @@ export default async function Page({ params }: { params: Params }) {
 
                 {/* Tags */}
                 {product.tags &&
-                  Array.isArray(product.tags) &&
-                  product.tags.length > 0 && (
-                    <div>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-sm font-medium">
-                          {t('tags')}:
-                        </span>
-                        {(product.tags as string[]).map((tag, index) => (
-                          <Badge
-                            key={index}
-                            variant="secondary"
-                            className="text-xs"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
+                  (() => {
+                    // Handle both formats: simple array or object with language keys
+                    let tagsToDisplay: string[] = [];
+
+                    if (Array.isArray(product.tags)) {
+                      // Old format: simple array of Persian tags
+                      tagsToDisplay = product.tags as string[];
+                    } else if (
+                      typeof product.tags === 'object' &&
+                      product.tags !== null
+                    ) {
+                      // New format: object with fa/en keys
+                      const tagsObj = product.tags as {
+                        fa?: string[];
+                        en?: string[];
+                      };
+                      if (
+                        params.locale === 'en' &&
+                        tagsObj.en &&
+                        tagsObj.en.length > 0
+                      ) {
+                        tagsToDisplay = tagsObj.en;
+                      } else if (tagsObj.fa) {
+                        tagsToDisplay = tagsObj.fa;
+                      }
+                    }
+
+                    return tagsToDisplay.length > 0 ? (
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium">
+                            {t('tags')}:
+                          </span>
+                          {tagsToDisplay.map((tag, index) => (
+                            <Link
+                              key={index}
+                              href={`/${params.locale}/explore?q=${encodeURIComponent(tag)}`}
+                              className="inline-block"
+                            >
+                              <Badge
+                                variant="secondary"
+                                className="text-xs cursor-pointer hover:bg-secondary/80 transition-colors"
+                              >
+                                {tag.replace(/_/g, ' ')}
+                              </Badge>
+                            </Link>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    ) : null;
+                  })()}
 
                 {/* Purchase Section */}
                 {product.stock > 0 && (

--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -379,7 +379,6 @@ async function processProductEnhancementAndAssessment({
   }
 
   let enhancedDescription = product.description;
-  let enhancedTags: string[] | undefined;
   let enhancedImageUrl = firstUploadedImageUrl;
   let enhancementSuccessful = false;
 
@@ -463,14 +462,19 @@ async function processProductEnhancementAndAssessment({
       if (enhancement.description || enhancement.tags || enhancement.title) {
         const enhancedTitle = enhancement.title || product.title;
         enhancedDescription = enhancement.description || product.description;
-        enhancedTags = enhancement.tags;
+
+        // Store tags as an object with language keys if we have English tags
+        const tagsToStore =
+          enhancement.tagsEn && enhancement.tagsEn.length > 0
+            ? { fa: enhancement.tags || [], en: enhancement.tagsEn }
+            : enhancement.tags; // Keep as simple array if no English tags
 
         await prisma.product.update({
           where: { id: product.id },
           data: {
             title: enhancedTitle,
             description: enhancedDescription,
-            tags: enhancedTags,
+            tags: tagsToStore,
           },
         });
         console.log(`✅ Enhanced title, description and tags saved`);

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -66,7 +66,6 @@ async function processProductEnhancementAndAssessment({
   }
 
   let enhancedDescription = product.description;
-  let enhancedTags: string[] | undefined;
   let enhancedImageUrl = firstUploadedImageUrl;
   let enhancementSuccessful = false;
 
@@ -150,14 +149,19 @@ async function processProductEnhancementAndAssessment({
       if (enhancement.description || enhancement.tags || enhancement.title) {
         const enhancedTitle = enhancement.title || product.title;
         enhancedDescription = enhancement.description || product.description;
-        enhancedTags = enhancement.tags;
+
+        // Store tags as an object with language keys if we have English tags
+        const tagsToStore =
+          enhancement.tagsEn && enhancement.tagsEn.length > 0
+            ? { fa: enhancement.tags || [], en: enhancement.tagsEn }
+            : enhancement.tags; // Keep as simple array if no English tags
 
         await prisma.product.update({
           where: { id: product.id },
           data: {
             title: enhancedTitle,
             description: enhancedDescription,
-            tags: enhancedTags,
+            tags: tagsToStore,
           },
         });
         console.log(`✅ Enhanced description and tags saved`);

--- a/lib/product-enhancement-openai.ts
+++ b/lib/product-enhancement-openai.ts
@@ -14,7 +14,8 @@ type EnhancementResult = {
   enhancedTitleEn?: string; // English translation of title if original is Persian
   enhancedDescription: string; // Persian/original language description
   enhancedDescriptionEn?: string; // English translation if original is Persian
-  suggestedTags: string[];
+  suggestedTags: string[]; // Tags in original language
+  suggestedTagsEn?: string[]; // English tags if original is Persian
   imageEnhancementTips?: string[];
   enhancedImageUrl?: string;
   confidence: number;
@@ -58,12 +59,14 @@ DESCRIPTION ENHANCEMENT GUIDELINES:
    - Be honest about imperfections (they add character!)
 
 TAG GENERATION RULES:
+- Use underscores for multi-word tags (e.g., hand_woven, custom_made, gift_ready)
 - Include material tags (wool, cotton, ceramic, etc.)
-- Add technique tags (handwoven, embroidered, painted, etc.)
+- Add technique tags (hand_woven, embroidered, painted, etc.)
 - Include style tags (traditional, modern, minimalist, etc.)
 - Add cultural tags if relevant (Persian, Iranian, ethnic, etc.)
 - Include functional tags (decorative, wearable, practical, etc.)
 - Maximum 10 tags, most relevant first
+- Keep tags concise and searchable (2-3 words max per tag)
 
 IMAGE ENHANCEMENT ANALYSIS:
 When analyzing the product image for realistic improvements, identify:
@@ -131,7 +134,8 @@ Analyze the product and provide enhancements. You MUST respond with valid JSON i
   "enhancedTitleEn": "English translation/version of title ONLY if original is Persian (max 100 chars, null if already English)",
   "enhancedDescription": "Improved description in ORIGINAL language (Persian if input is Persian, 300-500 chars)",
   "enhancedDescriptionEn": "English translation/version ONLY if original is Persian (300-500 chars, null if already English)",
-  "suggestedTags": ["tag1", "tag2", ...] (max 10),
+  "suggestedTags": ["tag1", "tag2", ...] (max 10 tags in ORIGINAL language, use underscores for multi-word tags),
+  "suggestedTagsEn": ["tag1_english", "tag2_english", ...] (English translations of tags ONLY if original is Persian, use underscores for multi-word tags, null if already English, max 10),
   "imageEnhancementTips": ["specific improvement suggestions for seller"],
   "imageEditPrompt": "Brief prompt for realistic photo enhancement focusing ONLY on: better lighting, clean background, sharp focus, correct colors. DO NOT change the product itself",
   "improvements": ["list of improvements made"],
@@ -208,6 +212,11 @@ Focus on highlighting handmade qualities and improving marketability.`,
                 items: { type: 'string' },
                 maxItems: 10,
               },
+              suggestedTagsEn: {
+                type: ['array', 'null'],
+                items: { type: 'string' },
+                maxItems: 10,
+              },
               imageEnhancementTips: {
                 type: 'array',
                 items: { type: 'string' },
@@ -229,6 +238,7 @@ Focus on highlighting handmade qualities and improving marketability.`,
               'enhancedDescription',
               'enhancedDescriptionEn',
               'suggestedTags',
+              'suggestedTagsEn',
               'imageEnhancementTips',
               'imageEditPrompt',
               'improvements',
@@ -253,6 +263,7 @@ Focus on highlighting handmade qualities and improving marketability.`,
       enhancedDescription: string;
       enhancedDescriptionEn?: string | null;
       suggestedTags: string[];
+      suggestedTagsEn?: string[] | null;
       imageEnhancementTips?: string[];
       imageEditPrompt?: string;
       improvements: string[];
@@ -280,6 +291,9 @@ Focus on highlighting handmade qualities and improving marketability.`,
       enhancedDescription: result.enhancedDescription,
       enhancedDescriptionEn: result.enhancedDescriptionEn || undefined,
       suggestedTags: result.suggestedTags.slice(0, 10),
+      suggestedTagsEn: result.suggestedTagsEn
+        ? result.suggestedTagsEn.slice(0, 10)
+        : undefined,
       imageEnhancementTips: result.imageEnhancementTips,
       enhancedImageUrl,
       confidence: Math.max(0, Math.min(100, result.confidence)),
@@ -438,6 +452,7 @@ export async function enhanceProductBeforeApproval(product: {
   description?: string;
   descriptionEn?: string;
   tags?: string[];
+  tagsEn?: string[];
   imageUrl?: string;
 }> {
   try {
@@ -492,6 +507,7 @@ export async function enhanceProductBeforeApproval(product: {
         description: enhancement.enhancedDescription || product.description,
         descriptionEn: enhancement.enhancedDescriptionEn,
         tags: enhancement.suggestedTags || [],
+        tagsEn: enhancement.suggestedTagsEn || [],
         imageUrl: enhancement.enhancedImageUrl || product.imageUrl,
       };
     }


### PR DESCRIPTION
## Summary
- Implement bilingual tag support so tags display in the correct language per locale
- Make tags clickable, linking to explore page with tag as search query
- Remove underscores from tag display for better UX

## Changes
- Updated OpenAI enhancement to generate bilingual tags (Persian and English)
- Modified product pages to display tags based on current locale
- Added clickable tag badges that navigate to explore page with search
- Replaced underscores with spaces in tag display
- Support both legacy array format and new object format for tags

## Test plan
- [x] Create/edit product and verify bilingual tags are generated
- [x] View product in Persian locale - tags show in Persian
- [x] View product in English locale - tags show in English
- [x] Click on tag - navigates to explore page with tag as search query
- [x] Tags display without underscores (e.g. "hand made" not "hand_made")

🤖 Generated with [Claude Code](https://claude.ai/code)