### PR TITLE
fix: Bypass stale cache to display correct translations and enhanced images

### DIFF
--- a/app/[locale]/explore/page.tsx
+++ b/app/[locale]/explore/page.tsx
@@ -8,8 +8,9 @@ import { ExploreFilters } from '@/components/explore/ExploreFilters';
 import { ExplorePagination } from '@/components/explore/ExplorePagination';
 import { SearchStats } from '@/components/explore/SearchStats';
 
-// Disable caching temporarily to test search functionality
+// Force cache revalidation to ensure fresh data
 export const revalidate = 0;
+export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: {

--- a/lib/search-cached.ts
+++ b/lib/search-cached.ts
@@ -6,14 +6,20 @@ import { CACHE_TAGS, CACHE_DURATIONS, createCachedFunction } from '@/lib/cache';
 
 /**
  * Cached version of searchProducts for better performance
+ * Note: Temporarily bypassing cache to ensure locale-specific content is fresh
  */
-export const searchProducts = createCachedFunction(
-  async (filters: SearchFilters) => {
-    return originalSearchProducts(filters);
-  },
-  [CACHE_TAGS.PRODUCTS, CACHE_TAGS.CATEGORIES],
-  CACHE_DURATIONS.MEDIUM // 30 minutes cache
-);
+export const searchProducts = async (filters: SearchFilters) => {
+  return originalSearchProducts(filters);
+};
+
+// Original cached version - restore after fixing locale-specific caching
+// export const searchProducts = createCachedFunction(
+//   async (filters: SearchFilters) => {
+//     return originalSearchProducts(filters);
+//   },
+//   [CACHE_TAGS.PRODUCTS, CACHE_TAGS.CATEGORIES],
+//   CACHE_DURATIONS.MEDIUM // 30 minutes cache
+// );
 
 /**
  * Cached featured products for homepage


### PR DESCRIPTION
## Summary
- Temporarily bypass search cache that was serving stale translations and original images
- Force dynamic rendering on explore page to ensure fresh content
- Fixes English page showing Farsi titles and non-enhanced images

## Root Cause
The search cache was holding stale data from before the translation and image enhancement fixes were deployed. The cache doesn't properly differentiate between locales, causing English users to see cached Farsi content.

## Changes
- Bypass cache in search-cached.ts temporarily 
- Add force-dynamic export to explore page
- Comments preserved for re-enabling cache after proper locale-aware implementation

## Test plan
- [x] Visit English explore page - titles now show in English
- [x] Enhanced images display first when available
- [x] Persian page still works correctly
- [x] Direct search returns correct locale-specific data

## Next Steps
- Implement proper locale-aware caching strategy
- Re-enable caching with locale as part of cache key

🤖 Generated with [Claude Code](https://claude.ai/code)