### PR TITLE
fix: Load product data correctly on edit page

### DIFF
--- a/app/[locale]/seller/products/[id]/edit/page.tsx
+++ b/app/[locale]/seller/products/[id]/edit/page.tsx
@@ -25,12 +25,14 @@ import ImageUploadManager from '@/components/seller/ImageUploadManager';
 interface FormCompatibleProduct {
   id: string;
   name: string;
+  title?: string;
   description: string;
   price: number;
+  priceToman?: number;
   stock: number;
-  category: string;
-  imageUrl: string;
-  tags?: string;
+  category?: string | { id: string; slug: string; name: string };
+  imageUrl?: string;
+  tags?: string | string[] | { fa?: string[]; en?: string[] };
   images?: Array<{
     id: string;
     url: string;
@@ -95,9 +97,19 @@ export default function EditProductPage() {
           category:
             productData.category?.slug || productData.category || 'textiles',
           imageUrl: productData.images?.[0]?.url || productData.imageUrl || '',
-          tags: Array.isArray(productData.tags)
-            ? productData.tags.join(', ')
-            : productData.tags || '',
+          tags: (() => {
+            if (Array.isArray(productData.tags)) {
+              return productData.tags.join(', ');
+            } else if (
+              typeof productData.tags === 'object' &&
+              productData.tags !== null
+            ) {
+              // Handle bilingual tags object {fa: [], en: []}
+              const fasiTags = productData.tags.fa || productData.tags.en || [];
+              return Array.isArray(fasiTags) ? fasiTags.join(', ') : '';
+            }
+            return typeof productData.tags === 'string' ? productData.tags : '';
+          })(),
         });
       } else {
         router.push('/seller/products');
@@ -205,7 +217,9 @@ export default function EditProductPage() {
             <Edit className="h-8 w-8 text-primary" />
             <div>
               <h1 className="text-3xl font-bold">{t('editProduct')}</h1>
-              <p className="text-muted-foreground">{product.name}</p>
+              <p className="text-muted-foreground">
+                {product.title || product.name}
+              </p>
             </div>
           </div>
         </div>
@@ -290,7 +304,11 @@ export default function EditProductPage() {
                       | 'painting'
                   )
                 }
-                defaultValue={product.category}
+                defaultValue={
+                  typeof product.category === 'object'
+                    ? product.category?.slug
+                    : product.category
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder={t('selectCategory')} />

--- a/app/api/seller/products/[id]/route.ts
+++ b/app/api/seller/products/[id]/route.ts
@@ -38,6 +38,12 @@ export async function GET(
         id: params.id,
         sellerId: user.sellerProfile.id,
       },
+      include: {
+        images: {
+          orderBy: { sortOrder: 'asc' },
+        },
+        category: true,
+      },
     });
 
     if (!product) {


### PR DESCRIPTION
## Summary
- Fixed product edit page to properly load existing product data including images, categories, and tags
- Resolved issue where tags were showing as `[object Object]`
- Fixed category dropdown not showing the current category

## Changes Made
1. **Updated GET endpoint** (`/api/seller/products/[id]/route.ts`):
   - Added `include` for `images` and `category` relations
   - Ensures all necessary data is fetched when loading edit page

2. **Fixed tags handling** in edit page:
   - Added logic to handle multiple tag formats (arrays, bilingual objects, strings)
   - Properly extracts Persian tags from bilingual structure

3. **Fixed category dropdown**:
   - Updated to handle category as object with `slug` property
   - Correctly displays current category when editing

4. **Updated TypeScript types**:
   - Fixed `FormCompatibleProduct` interface to match actual data structure
   - All type checking now passes

## Test Plan
- [x] Load product edit page and verify images are displayed
- [x] Verify category dropdown shows current category
- [x] Verify tags display correctly (not as `[object Object]`)
- [x] Test updating product with and without AI
- [x] Run `npm run typecheck` - passes
- [x] Run `npm run lint` - passes

🤖 Generated with [Claude Code](https://claude.ai/code)