### PR TITLE
fix: preserve case sensitivity in middleware for dynamic route params

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -11,14 +11,16 @@ const intlMiddleware = createMiddleware({
 
 export default async function middleware(req: NextRequest) {
   // Apply auth check only to protected routes
-  const pathname = req.nextUrl.pathname.toLowerCase();
+  const pathname = req.nextUrl.pathname;
   const normalizedPath = pathname.replace(/\/+/g, '/').replace(/\.\./g, '');
   const pathSegments = normalizedPath.split('/').filter(Boolean);
 
   const isProtectedPath =
     pathSegments.length >= 2 &&
-    (pathSegments[0] === 'fa' || pathSegments[0] === 'en') &&
-    (pathSegments[1] === 'seller' || pathSegments[1] === 'admin');
+    (pathSegments[0].toLowerCase() === 'fa' ||
+      pathSegments[0].toLowerCase() === 'en') &&
+    (pathSegments[1].toLowerCase() === 'seller' ||
+      pathSegments[1].toLowerCase() === 'admin');
 
   // If the URL contains an explicit locale prefix
   const isLocalePrefixed =
@@ -40,8 +42,8 @@ export default async function middleware(req: NextRequest) {
     }
 
     // Check role-based access
-    const isSellerPath = pathSegments[1] === 'seller';
-    const isAdminPath = pathSegments[1] === 'admin';
+    const isSellerPath = pathSegments[1].toLowerCase() === 'seller';
+    const isAdminPath = pathSegments[1].toLowerCase() === 'admin';
 
     if (isSellerPath && session.user.role !== 'SELLER') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });


### PR DESCRIPTION
The middleware was converting entire pathname to lowercase, breaking navigation to routes with case-sensitive IDs (e.g., /seller/products/cm4Abc123/edit).

This caused edit buttons to reload the page instead of navigating to the edit page.

Changes:
- Remove toLowerCase() from pathname to preserve case-sensitive dynamic params
- Apply lowercase comparison only to locale and route segments ('fa', 'en', 'seller', 'admin')
- Maintains security normalization while fixing route matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)