### PR TITLE
fix: correct Button-Link nesting for edit and view navigation

### DIFF
--- a/app/[locale]/seller/products/page.tsx
+++ b/app/[locale]/seller/products/page.tsx
@@ -222,24 +222,30 @@ export default function SellerProductsPage() {
                   </div>
 
                   <div className="flex gap-2">
-                    <Link
-                      href={`/${locale}/product/${product.slug}`}
+                    <Button
+                      variant="outline"
+                      size="sm"
                       className="flex-1"
+                      asChild
                     >
-                      <Button variant="outline" size="sm" className="w-full">
+                      <Link href={`/${locale}/product/${product.slug}`}>
                         <Eye className="h-4 w-4 mr-1" />
                         {t('view')}
-                      </Button>
-                    </Link>
-                    <Link
-                      href={`/${locale}/seller/products/${product.id}/edit`}
+                      </Link>
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
                       className="flex-1"
+                      asChild
                     >
-                      <Button variant="outline" size="sm" className="w-full">
+                      <Link
+                        href={`/${locale}/seller/products/${product.id}/edit`}
+                      >
                         <Edit className="h-4 w-4 mr-1" />
                         {t('edit')}
-                      </Button>
-                    </Link>
+                      </Link>
+                    </Button>
                     <Button
                       variant="outline"
                       size="sm"


### PR DESCRIPTION
The edit and view buttons were not navigating properly because Button components were nested inside Link components, creating invalid HTML with nested interactive elements.

This caused the edit button to reload the page instead of navigating to the edit route.

Solution:
- Use Button's asChild prop with Link as child (Radix UI pattern)
- This properly merges props and creates valid anchor elements
- Fixes both View and Edit button navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)